### PR TITLE
Update Conduit Demo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 <img src="media/stacks_hr.gif"  />
 </p>
 
-<a href="https://demo.realworld.io/"><img src="media/conduit_l.png" align="right" width="250px" /></a>
+<a href="https://conduit.realworld.how/"><img src="media/conduit_l.png" align="right" width="250px" /></a>
 
-### See how _the exact same_ Medium.com clone (called [Conduit](https://demo.realworld.io)) is built using different [frontends](https://codebase.show/projects/realworld?category=frontend) and [backends](https://codebase.show/projects/realworld?category=backend). Yes, you can mix and match them, because **they all adhere to the same [API spec](https://realworld-docs.netlify.app/docs/specs/backend-specs/introduction)** 😮😎
+### See how _the exact same_ Medium.com clone (called [Conduit](https://conduit.realworld.how)) is built using different [frontends](https://codebase.show/projects/realworld?category=frontend) and [backends](https://codebase.show/projects/realworld?category=backend). Yes, you can mix and match them, because **they all adhere to the same [API spec](https://realworld-docs.netlify.app/docs/specs/backend-specs/introduction)** 😮😎
 
 While most "todo" demos provide an excellent cursory glance at a framework's capabilities, they typically don't convey the knowledge & perspective required to actually build _real_ applications with it.
 
-**RealWorld** solves this by allowing you to choose any frontend (React, Angular, & more) and any backend (Node, Django, & more) and see how they power a real-world, beautifully designed full-stack app called [**Conduit**](https://demo.realworld.io).
+**RealWorld** solves this by allowing you to choose any frontend (React, Angular, & more) and any backend (Node, Django, & more) and see how they power a real-world, beautifully designed full-stack app called [**Conduit**](https://conduit.realworld.how).
 
 _Read the [full blog post announcing RealWorld on Medium.](https://medium.com/@ericsimons/introducing-realworld-6016654d36b5)_
 

--- a/apps/documentation/docs/implementation-creation/introduction.md
+++ b/apps/documentation/docs/implementation-creation/introduction.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 # Introduction
 
 **Conduit** is a social blogging site (i.e. a Medium.com clone). It uses a custom API for all requests, including authentication.
-Discover our [live demo](https://demo.realworld.io).
+Discover our [live demo](https://conduit.realworld.how).
 
 :::tip
 Check for [Discussions](https://github.com/gothinkster/realworld/discussions/categories/wip-implementations) about works in progress as we don't list duplicate projects.  

--- a/apps/documentation/docs/intro.mdx
+++ b/apps/documentation/docs/intro.mdx
@@ -10,11 +10,11 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
   <img src={useBaseUrl('/img/conduit_l.png')} align="right" width="250px" />
 </a>
 
-> See how _the exact same_ Medium.com clone (called [Conduit](https://demo.realworld.io)) is built using different [frontends](https://codebase.show/projects/realworld?category=frontend) and [backends](https://codebase.show/projects/realworld?category=backend). Yes, you can mix and match them, because **they all adhere to the same [API spec](specs/backend-specs/introduction)** 😮😎
+> See how _the exact same_ Medium.com clone (called [Conduit](https://conduit.realworld.how)) is built using different [frontends](https://codebase.show/projects/realworld?category=frontend) and [backends](https://codebase.show/projects/realworld?category=backend). Yes, you can mix and match them, because **they all adhere to the same [API spec](specs/backend-specs/introduction)** 😮😎
 
 While most "todo" demos provide an excellent cursory glance at a framework's capabilities, they typically don't convey the knowledge & perspective required to actually build _real_ applications with it.
 
-**RealWorld** solves this by allowing you to choose any frontend (React, Angular, & more) and any backend (Node, Django, & more) and see how they power a real world, beautifully designed fullstack app called [**Conduit**](https://demo.realworld.io).
+**RealWorld** solves this by allowing you to choose any frontend (React, Angular, & more) and any backend (Node, Django, & more) and see how they power a real world, beautifully designed fullstack app called [**Conduit**](https://conduit.realworld.how).
 
 _Read the [full blog post announcing RealWorld on Medium.](https://medium.com/@ericsimons/introducing-realworld-6016654d36b5)_
 

--- a/apps/documentation/src/pages/index.js
+++ b/apps/documentation/src/pages/index.js
@@ -26,7 +26,7 @@ function HomepageHeader() {
                 framework.
               </p>
               <div className={styles.buttons}>
-                <Link className="button button--primary button--lg" to="https://demo.realworld.io">
+                <Link className="button button--primary button--lg" to="https://conduit.realworld.how">
                   discover our demo
                 </Link>
               </div>

--- a/apps/e2e-testing-cypress/cypress.config.ts
+++ b/apps/e2e-testing-cypress/cypress.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     ...nxE2EPreset(__dirname, {
       bundler: 'webpack',
     }),
-    baseUrl: 'https://demo.realworld.io',
+    baseUrl: 'https://conduit.realworld.how',
     experimentalRunAllSpecs: true,
     env: {
       prefix: 'schmilblick',

--- a/apps/e2e-testing-cypress/project.json
+++ b/apps/e2e-testing-cypress/project.json
@@ -8,7 +8,7 @@
       "executor": "@nx/cypress:cypress",
       "options": {
         "cypressConfig": "apps/e2e-testing-cypress/cypress.config.ts",
-        "baseUrl": "https://demo.realworld.io",
+        "baseUrl": "https://conduit.realworld.how",
         "testingType": "e2e"
       },
       "configurations": {


### PR DESCRIPTION
This PR updates the Conduit demo URL from `https://demo.realworld.io` to `https://conduit.realworld.how` across the entire project.